### PR TITLE
Updated coverlet version.

### DIFF
--- a/PresidentialGameEngine.ClassLibrary.Tests/PresidentialGameEngine.ClassLibrary.Tests.csproj
+++ b/PresidentialGameEngine.ClassLibrary.Tests/PresidentialGameEngine.ClassLibrary.Tests.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
Updated the Coverlet version.

JetBrains Rider (which I am now using after switching away from Windows) has automatically detected that there is an issue in Coverlet 6.0.0. The CVE is described here.

https://www.mend.io/vulnerability-database/CVE-2024-21907/?utm_source=JetBrains